### PR TITLE
Bugfix: Small boiler ash types mixing

### DIFF
--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
@@ -10,6 +10,7 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Pollution;
 import gregtech.common.gui.GT_Container_Boiler;
 import gregtech.common.gui.GT_GUIContainer_Boiler;
@@ -17,6 +18,7 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidHandler;
+import net.minecraft.item.ItemStack;
 
 public class GT_MetaTileEntity_Boiler_Bronze
         extends GT_MetaTileEntity_Boiler {
@@ -126,8 +128,8 @@ public class GT_MetaTileEntity_Boiler_Bronze
             
             if ((this.mProcessingEnergy <= 0) && (aBaseMetaTileEntity.isAllowedToWork()) &&
                     (this.mInventory[2] != null) && !byproductStuffed) {
-                int fuelEnergy, byproductChance;
-                Object byproduct;
+                int fuelEnergy = 0, byproductChance = 1;
+                Object byproduct = Materials.Ash;
                 boolean validFuel = false;
                 if ((GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.gem.get(Materials.Coal))) || 
                     (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dust.get(Materials.Coal))) || 
@@ -167,7 +169,7 @@ public class GT_MetaTileEntity_Boiler_Bronze
                         if(!aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, byproduct, 1L))) {
                             //We can only get here if the output wasn't stuffed, so if the add fails, it can only be because the byproduct types don't match
                             //Have attempted to mix ash types, so add one to the size of the stack and convert all ash to light ashes
-                            aBaseMetaTileEntity.setInventorySlotContents(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Ash, byproductStack.stackSize + 1)) {
+                            aBaseMetaTileEntity.setInventorySlotContents(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Ash, byproductStack.stackSize + 1));
                         }
                     }
                 }

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
@@ -15,10 +15,10 @@ import gregtech.common.GT_Pollution;
 import gregtech.common.gui.GT_Container_Boiler;
 import gregtech.common.gui.GT_GUIContainer_Boiler;
 import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidHandler;
-import net.minecraft.item.ItemStack;
 
 public class GT_MetaTileEntity_Boiler_Bronze
         extends GT_MetaTileEntity_Boiler {

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
@@ -114,31 +114,61 @@ public class GT_MetaTileEntity_Boiler_Bronze
                 sendSound((byte) 1);
                 this.mSteam.amount = 12000;
             }
+            
+            //Check the boiler has not been choked by output and can keep burning fuel
+            boolean byproductStuffed = false;
+            
+            ItemStack byproductStack = aBaseMetaTileEntity.getStackInSlot(3);
+            
+            if(byproductStack != null && !(GT_Utility.isStackInvalid(byproductStack)) && byproductStack.stackSize == byproductStack.getMaxStackSize()) {
+                byproductStuffed = true;
+            }
+            
             if ((this.mProcessingEnergy <= 0) && (aBaseMetaTileEntity.isAllowedToWork()) &&
-                    (this.mInventory[2] != null)) {
-                if ((GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.gem.get(Materials.Coal))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dust.get(Materials.Coal))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dustImpure.get(Materials.Coal))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.crushed.get(Materials.Coal)))) {
-                    this.mProcessingEnergy += 160;
-                    aBaseMetaTileEntity.decrStackSize(2, 1);
-                    if (aBaseMetaTileEntity.getRandomNumber(3) == 0) {
-                        aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L));
-                    }
-                } else if ((GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.gem.get(Materials.Charcoal))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dust.get(Materials.Charcoal))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dustImpure.get(Materials.Charcoal))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.crushed.get(Materials.Charcoal)))) {
-                    this.mProcessingEnergy += 160;
-                    aBaseMetaTileEntity.decrStackSize(2, 1);
-                    if (aBaseMetaTileEntity.getRandomNumber(3) == 0) {
-                        aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Ash, 1L));
-                    }
+                    (this.mInventory[2] != null) && !byproductStuffed) {
+                int fuelEnergy, byproductChance;
+                Object byproduct;
+                boolean validFuel = false;
+                if ((GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.gem.get(Materials.Coal))) || 
+                    (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dust.get(Materials.Coal))) || 
+                    (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dustImpure.get(Materials.Coal))) || 
+                    (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.crushed.get(Materials.Coal)))) {
+                    fuelEnergy = 160;
+                    byproductChance = 3;
+                    byproduct = Materials.DarkAsh;
+                    validFuel = true;
+                } else if ((GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.gem.get(Materials.Charcoal))) || 
+                           (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dust.get(Materials.Charcoal))) || 
+                           (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dustImpure.get(Materials.Charcoal))) || 
+                           (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.crushed.get(Materials.Charcoal)))) {
+                    fuelEnergy = 160;
+                    byproductChance = 3;
+                    byproduct = Materials.Ash;
+                    validFuel = true;
                 } else if (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelCoke")) {
-                    this.mProcessingEnergy += 640;
+                    fuelEnergy = 640;
+                    byproductChance = 2;
+                    byproduct = Materials.Ash;
+                    validFuel = true;
+                } else if ((GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.gem.get(Materials.Lignite))) || 
+                           (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dust.get(Materials.Lignite))) || 
+                           (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dustImpure.get(Materials.Lignite))) || 
+                           (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.crushed.get(Materials.Lignite)))) {
+                    fuelEnergy = 120;
+                    byproductChance = 8;
+                    byproduct = Materials.DarkAsh;
+                    validFuel = true;
+                }
+                
+                if(validFuel) {
+                    this.mProcessingEnergy += fuelEnergy;
                     aBaseMetaTileEntity.decrStackSize(2, 1);
-                    if (aBaseMetaTileEntity.getRandomNumber(2) == 0) {
-                        aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Ash, 1L));
-                    }
-                } else if ((GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.gem.get(Materials.Lignite))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dust.get(Materials.Lignite))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dustImpure.get(Materials.Lignite))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.crushed.get(Materials.Lignite)))) {
-                    this.mProcessingEnergy += 120;
-                    aBaseMetaTileEntity.decrStackSize(2, 1);
-                    if (aBaseMetaTileEntity.getRandomNumber(8) == 0) {
-                        aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L));
+                    if (aBaseMetaTileEntity.getRandomNumber(byproductChance) == 0) {
+                        if(!aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, byproduct, 1L))) {
+                            //We can only get here if the output wasn't stuffed, so if the add fails, it can only be because the byproduct types don't match
+                            //Have attempted to mix ash types, so add one to the size of the stack and convert all ash to light ashes
+                            aBaseMetaTileEntity.setInventorySlotContents(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Ash, byproductStack.stackSize + 1)) {
+                        }
                     }
                 }
             }

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Steel.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Steel.java
@@ -10,10 +10,12 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Pollution;
 import gregtech.common.gui.GT_Container_Boiler;
 import gregtech.common.gui.GT_GUIContainer_Boiler;
 import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidHandler;
@@ -119,31 +121,61 @@ public class GT_MetaTileEntity_Boiler_Steel
                 sendSound((byte) 1);
                 this.mSteam.amount = 24000;
             }
+
+            //Check the boiler has not been choked by output and can keep burning fuel
+            boolean byproductStuffed = false;
+
+            ItemStack byproductStack = aBaseMetaTileEntity.getStackInSlot(3);
+
+            if(byproductStack != null && !(GT_Utility.isStackInvalid(byproductStack)) && byproductStack.stackSize == byproductStack.getMaxStackSize()) {
+                byproductStuffed = true;
+            }
+
             if ((this.mProcessingEnergy <= 0) && (aBaseMetaTileEntity.isAllowedToWork()) &&
-                    (this.mInventory[2] != null)) {
-                if ((GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.gem.get(Materials.Coal))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dust.get(Materials.Coal))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dustImpure.get(Materials.Coal))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.crushed.get(Materials.Coal)))) {
-                    this.mProcessingEnergy += 160;
-                    aBaseMetaTileEntity.decrStackSize(2, 1);
-                    if (aBaseMetaTileEntity.getRandomNumber(3) == 0) {
-                        aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L));
-                    }
-                } else if ((GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.gem.get(Materials.Charcoal))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dust.get(Materials.Charcoal))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dustImpure.get(Materials.Charcoal))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.crushed.get(Materials.Charcoal)))) {
-                    this.mProcessingEnergy += 160;
-                    aBaseMetaTileEntity.decrStackSize(2, 1);
-                    if (aBaseMetaTileEntity.getRandomNumber(3) == 0) {
-                        aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Ash, 1L));
-                    }
+                    (this.mInventory[2] != null) && !byproductStuffed) {
+                int fuelEnergy = 0, byproductChance = 1;
+                Object byproduct = Materials.Ash;
+                boolean validFuel = false;
+                if ((GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.gem.get(Materials.Coal))) ||
+                    (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dust.get(Materials.Coal))) ||
+                    (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dustImpure.get(Materials.Coal))) ||
+                    (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.crushed.get(Materials.Coal)))) {
+                    fuelEnergy = 160;
+                    byproductChance = 3;
+                    byproduct = Materials.DarkAsh;
+                    validFuel = true;
+                } else if ((GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.gem.get(Materials.Charcoal))) ||
+                           (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dust.get(Materials.Charcoal))) ||
+                           (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dustImpure.get(Materials.Charcoal))) ||
+                           (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.crushed.get(Materials.Charcoal)))) {
+                    fuelEnergy = 160;
+                    byproductChance = 3;
+                    byproduct = Materials.Ash;
+                    validFuel = true;
                 } else if (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelCoke")) {
-                    this.mProcessingEnergy += 640;
+                    fuelEnergy = 640;
+                    byproductChance = 2;
+                    byproduct = Materials.Ash;
+                    validFuel = true;
+                } else if ((GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.gem.get(Materials.Lignite))) ||
+                           (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dust.get(Materials.Lignite))) ||
+                           (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dustImpure.get(Materials.Lignite))) ||
+                           (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.crushed.get(Materials.Lignite)))) {
+                    fuelEnergy = 120;
+                    byproductChance = 8;
+                    byproduct = Materials.DarkAsh;
+                    validFuel = true;
+                }
+
+                if(validFuel) {
+                    this.mProcessingEnergy += fuelEnergy;
                     aBaseMetaTileEntity.decrStackSize(2, 1);
-                    if (aBaseMetaTileEntity.getRandomNumber(2) == 0) {
-                        aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Ash, 1L));
-                    }
-                } else if ((GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.gem.get(Materials.Lignite))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dust.get(Materials.Lignite))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.dustImpure.get(Materials.Lignite))) || (GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.crushed.get(Materials.Lignite)))) {
-                    this.mProcessingEnergy += 120;
-                    aBaseMetaTileEntity.decrStackSize(2, 1);
-                    if (aBaseMetaTileEntity.getRandomNumber(8) == 0) {
-                        aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L));
+                    if (aBaseMetaTileEntity.getRandomNumber(byproductChance) == 0) {
+                        if(!aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, byproduct, 1L))) {
+                            //We can only get here if the output wasn't stuffed, so if the add fails, it can only be because the byproduct types don't match
+                            //Have attempted to mix ash types, so add one to the size of the stack and convert all ash to light ashes
+                            aBaseMetaTileEntity.setInventorySlotContents(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Ash, byproductStack.stackSize + 1));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Issue: Small boilers that had ash in the byproduct slot would not produce more byproduct if the fuel type was changed to one that produced a different type of ash e.g. burn a couple of coal until there is one DarkAsh in the byproduct slot, then charcoal will produce no Ash in that stack
Fix: When mixing ash types, convert all the ash to less valuable light ashes - prevents any exploits for creating more dark ashes.
Issue: Boilers did not stop burning fuel when full of ash
Fix: added explicit check so that boilers can't burn fuel when output is stuffed (this may be a balance change, so can be removed if undesirable) 
Small refactoring of fuel logic so that ash conversion logic does not need to be repeated
Started with small bronze boiler, will extend fix to small steel boiler if general structure approved

Addresses issue #1302